### PR TITLE
Fix vr/metadata 20220712 nakazawa2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,4 @@ repos:
   rev: v2.9.6
   hooks:
   - id: jshint
+    language_version: 14.20.0

--- a/addons/metadata/static/files.js
+++ b/addons/metadata/static/files.js
@@ -215,14 +215,21 @@ function MetadataButtons() {
     if (!self.lastFields) {
       return;
     }
+    const fieldSetsAndValues = [];
     self.lastFields.forEach(function(fieldSet) {
       const value = fieldSet.field.getValue(fieldSet.input);
+      fieldSetsAndValues.push({ fieldSet: fieldSet, value: value });
+    });
+    fieldSetsAndValues.forEach(function(fieldSetAndValue) {
+      const fieldSet = fieldSetAndValue.fieldSet;
+      const value = fieldSetAndValue.value;
       var error = null;
       try {
         metadataFields.validateField(
           self.erad,
           fieldSet.question,
-          value
+          value,
+          fieldSetsAndValues
         );
       } catch(e) {
         error = e.message;
@@ -890,34 +897,44 @@ function MetadataButtons() {
     container.empty();
     var errors = 0;
     self.lastFields = [];
+    const fieldSetsAndValues = [];
     fields.forEach(function(fieldSet) {
       const errorContainer = $('<div></div>')
         .css('color', 'red').hide();
       const input = fieldSet.field.addElementTo(container, errorContainer);
       const value = fieldSet.field.getValue(input);
+      fieldSetsAndValues.push({
+        fieldSet: {
+          field: fieldSet.field,
+          question: fieldSet.question,
+          input: input,
+          lastError: null,
+          errorContainer: errorContainer
+        },
+        value: value
+      });
+    });
+    fieldSetsAndValues.forEach(function(fieldSetAndValue) {
+      const fieldSet = fieldSetAndValue.fieldSet;
+      const value = fieldSetAndValue.value;
       var error = null;
       try {
         metadataFields.validateField(
           self.erad,
           fieldSet.question,
-          value
+          value,
+          fieldSetsAndValues
         );
       } catch(e) {
         error = e.message;
       }
       if (error) {
-        errorContainer.text(error).show()
+        fieldSet.errorContainer.text(error).show()
         errors ++;
       } else {
-        errorContainer.hide().text('')
+        fieldSet.errorContainer.hide().text('')
       }
-      self.lastFields.push({
-        field: fieldSet.field,
-        question: fieldSet.question,
-        input: input,
-        lastError: error,
-        errorContainer: errorContainer
-      });
+      self.lastFields.push(fieldSet);
     });
     const message = $('<div></div>');
     if (errors) {

--- a/addons/metadata/static/metadata-fields.js
+++ b/addons/metadata/static/metadata-fields.js
@@ -34,7 +34,10 @@ function createField(erad, question, valueEntry, options, callback) {
   throw new Error('Unsupported type: ' + question.type);
 }
 
-function validateField(erad, question, value) {
+function validateField(erad, question, value, fieldSetAndValues) {
+  if (question.qid == 'grdm-file:available-date') {
+    return validateAvailableDateField(erad, question, value, fieldSetAndValues);
+  }
   if (!value) {
     if (question.required) {
       throw new Error(_("This field can't be blank."))
@@ -173,6 +176,17 @@ function validateStringField(erad, question, value) {
 }
 
 function validateChooseField(erad, question, value) {
+}
+
+function validateAvailableDateField(erad, question, value, fieldSetAndValues) {
+  const accessRightsPair = fieldSetAndValues.find(function(fieldSetAndValue) {
+    return fieldSetAndValue.fieldSet.question.qid === 'grdm-file:access-rights';
+  })
+  if (!accessRightsPair) return;
+  const requiredDateAccessRights = ['embargoed access'];
+  if (requiredDateAccessRights.includes(accessRightsPair.value) && !value) {
+    throw new Error(_("This field can't be blank."));
+  }
 }
 
 function createChooser(options) {

--- a/addons/metadata/static/metadata-fields.js
+++ b/addons/metadata/static/metadata-fields.js
@@ -185,6 +185,9 @@ function createChooser(options) {
       return;
     }
     const optElem = $('<option></option>').attr('value', opt.text).text(getLocalizedText(opt.tooltip));
+    if (opt.default) {
+      optElem.attr('selected', true);
+    }
     select.append(optElem);
   });
   return select;

--- a/api/schemas/serializers.py
+++ b/api/schemas/serializers.py
@@ -41,6 +41,7 @@ class RegistrationSchemaBlockSerializer(JSONAPISerializer):
     help_text = ser.CharField(read_only=True)
     example_text = ser.CharField(read_only=True)
     required = ser.BooleanField(read_only=True)
+    default = ser.BooleanField(read_only=True)
     index = ser.IntegerField(read_only=True, source='_order')
 
     links = LinksField({

--- a/osf/migrations/0222_add_default_to_registration_schema_block.py
+++ b/osf/migrations/0222_add_default_to_registration_schema_block.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('osf', '0221_ensure_schema_and_reports'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='registrationschemablock',
+            name='default',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/osf/migrations/0223_ensure_schema_and_reports.py
+++ b/osf/migrations/0223_ensure_schema_and_reports.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+from osf.utils.migrations import UpdateRegistrationSchemasAndSchemaBlocks
+
+
+def ensure_registration_reports(*args):
+    from api.base import settings
+    from addons.metadata import FULL_NAME
+    from addons.metadata.utils import ensure_registration_report
+    from addons.metadata.report_format import REPORT_FORMATS
+    if FULL_NAME not in settings.INSTALLED_APPS:
+        return
+    for schema_name, report_name, csv_template in REPORT_FORMATS:
+        ensure_registration_report(schema_name, report_name, csv_template)
+
+def noop(*args):
+    pass
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('osf', '0222_add_default_to_registration_schema_block'),
+    ]
+
+    operations = [
+        UpdateRegistrationSchemasAndSchemaBlocks(),
+        migrations.RunPython(ensure_registration_reports, noop),
+    ]

--- a/osf/models/metaschema.py
+++ b/osf/models/metaschema.py
@@ -189,6 +189,7 @@ class RegistrationSchemaBlock(ObjectIDMixin, BaseModel):
     block_type = models.CharField(max_length=31, db_index=True, choices=SCHEMABLOCK_TYPES)
     display_text = models.TextField()
     required = models.BooleanField(default=False)
+    default = models.BooleanField(default=False)
 
     @property
     def absolute_api_v2_url(self):

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,7 +5,7 @@
 # Testing
 pytest==5.0.0
 pytest-socket==0.3.5
-pytest-xdist==1.15.0
+pytest-xdist==1.34.0
 pytest-django==3.10.0
 python-coveralls==2.9.3
 pytest-testmon==1.0.3

--- a/website/project/metadata/e-rad-metadata-1.json
+++ b/website/project/metadata/e-rad-metadata-1.json
@@ -133,7 +133,7 @@
           "title": "データ No.|Data No.",
           "type": "string",
           "format": "text",
-          "required": true
+          "required": false
         },
         {
           "qid": "grdm-file:title-ja",
@@ -157,7 +157,7 @@
           "title": "掲載日・掲載更新日|Date (Issued / Updated)",
           "type": "string",
           "format": "date",
-          "required": true
+          "required": false
         },
         {
           "qid": "grdm-file:data-description-ja",
@@ -184,7 +184,8 @@
           "options": [
               {
                 "text": "project",
-                "tooltip": "プロジェクトに指定された分野|The field specified for the project"
+                "tooltip": "プロジェクトの研究分野|Research field of the project",
+                "default": true
               },
               {
                 "text": "189",
@@ -242,7 +243,8 @@
           "options": [
               {
                 "text": "dataset",
-                "tooltip": "データセット|dataset"
+                "tooltip": "データセット|dataset",
+                "default": true
               },
               {
                   "text": "conference paper",
@@ -521,7 +523,7 @@
           "title": "リポジトリ情報 (日本語)|Repository information (Japanese)",
           "type": "string",
           "format": "text",
-          "required": true
+          "required": false
         },
         {
           "qid": "grdm-file:repo-information-en",
@@ -529,7 +531,7 @@
           "title": "Repository information (English)",
           "type": "string",
           "format": "text",
-          "required": true
+          "required": false
         },
         {
           "qid": "grdm-file:repo-url-doi-link",

--- a/website/project/metadata/e-rad-metadata-1.json
+++ b/website/project/metadata/e-rad-metadata-1.json
@@ -29,7 +29,7 @@
             },
             {
               "text": "BRAIN",
-              "tooltip": "国立研究開発法人農業・食品産業技術総合研究機構|National Agriculture and Food Research Organization|1205"
+              "tooltip": "生物系特定産業技術研究支援センター|Bio-oriented Technology Research Advancement Institution|1205"
             }
           ],
           "required": true


### PR DESCRIPTION
- 9fb7a4a fix BRAIN tooltip
    - GRDM-31419
        - e-rad スキーマの修正 ... テキスト修正: BRAIN
- be02646 add options.default property to metadata schema and update e-rad schema
    - GRDM-32614
        - metadata schema の default option の実装 ref: ember [c18ad3c](https://github.com/yacchin1205/RDM-ember-osf-web/pull/14/commits/c18ad3cac955cbf9fefb98e9df2d25ba45882c5c) ([PR #14](https://github.com/yacchin1205/RDM-ember-osf-web/pull/14))
        - e-rad スキーマの修正 ... default設定とテキスト修正: データの分野 , データ種別
    - GRDM-32613
        - e-rad スキーマの修正 ... required=falseに: データ No. , 掲載日・掲載更新日 , リポジトリ情報 (ja, en)
- af4aa0f add conditionally required for available-date
    - GRDM-32614
        - アクセス権が embagoed access のときのみ 公開予定日 を必須にした
- ca375d6 bump xdist version to fix GHA ci

ca375d6 について。
前 commit まで、 pytest-xdist のインストールが失敗していました。
https://app.travis-ci.com/github/yacchin1205/RDM2-osf.io/jobs/576500837

```
Collecting pytest-xdist==1.15.0
  Using cached pytest-xdist-1.15.0.tar.gz (87 kB)
  Preparing metadata (setup.py) ... error

(中略)
    File "/tmp/pip-wheel-o_5dj_r3/pytest-xdist_7c76ea1a9c7f47d3946285f48d8747e5/.eggs/setuptools_scm-7.0.5-py3.6.egg/setuptools_scm/__init__.py", line 5
      from __future__ import annotations
      ^
  SyntaxError: future feature annotations is not defined
```

pytest-xdist==1.15.0 のインストールに必要な setuptools-scm が v7.0.0 で Python 3.6 のサポートを終了していました。
https://github.com/pypa/setuptools_scm/commit/d65a0377a71b2915107d4e816c0f5e1724d42f82#diff-2c623f3c6a917be56c59d43279244996836262cb1e12d9d0786c9c49eef6b43c
setuptools-scm>=7.0.0 は Python 3.7 から使える __feature__.annotations を利用しています。TravisCI では(Docker Image でも) Python 3.6 を使っています。それで上記のエラーが発生するようです。
なお、 setuptools-scm v7.0.0 2022/06/22 にリリースされたので比較的最近です。

なぜ他のブランチや RCOSDP/develop ではエラーにならないかというと、リポジトリに残っている pytest-xdist の cache を利用できているからに見えます。
https://app.travis-ci.com/github/RCOSDP/RDM-osf.io/jobs/576260517#L1188

```
Processing /home/travis/.cache/wheelhouse/pytest_xdist-1.15.0-py2.py3-none-any.whl
  File was already downloaded /home/travis/.cache/wheelhouse/pytest_xdist-1.15.0-py2.py3-none-any.whl
```

自分のPRでは、なぜかキャッシュのダウンロードに失敗しています。
https://app.travis-ci.com/github/yacchin1205/RDM2-osf.io/jobs/576500837#L461-L464

本家のほうで、pytest-xdist のバージョンを 1.34.0 にアップグレードしている commit をみつけたので、cherry-pick しました。
#78 のCIではこの問題が解決されています。

ただし、 jshint のインストールに失敗する問題が残っています。
これ他が動くのはキャッシュが利用できているからに見えます。
原因・解決策はまだ調査中です。Nodeのバージョンを変更したら解決したという記事を見かけたので、 #80 で Node 14.20.0 に変更してみています。（今は v8 を使っているのですね。古い...）
