### PR TITLE
Add PR coverage comment workflow

### DIFF
--- a/.github/scripts/ci/run-tests.sh
+++ b/.github/scripts/ci/run-tests.sh
@@ -8,8 +8,13 @@ if [ "$#" -ne 1 ]; then
 fi
 
 TEST_BUILD="$1"
+ENABLE_COVERAGE="${ENABLE_COVERAGE:-false}"
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "$REPO_ROOT"
+
+if [ "$ENABLE_COVERAGE" = "true" ]; then
+    rm -f ".coverage.${TEST_BUILD}"
+fi
 
 compose_files=(-f docker-compose.yml -f .github/docker-compose.ci.override.yml)
 compose() {
@@ -93,10 +98,16 @@ pip3 install uritemplate.py==0.3.0
 if [ "$TEST_BUILD" = "api1_and_js" ]; then
     invoke assets --dev
 fi
-invoke "test_travis_${TEST_BUILD}" -n 1
+coverage_args=()
+if [ "$ENABLE_COVERAGE" = "true" ]; then
+    export COVERAGE_FILE="/code/.coverage.${TEST_BUILD}"
+    coverage_args+=(--coverage)
+fi
+invoke "test_travis_${TEST_BUILD}" -n 1 "${coverage_args[@]}"
 BASH
 
 compose run --rm \
+    -e ENABLE_COVERAGE="$ENABLE_COVERAGE" \
     -e TEST_BUILD="$TEST_BUILD" \
     -e BOWER_ALLOW_ROOT=1 \
     -e NPM_CONFIG_FORCE=true \

--- a/.github/workflows/pr-coverage-comment.yml
+++ b/.github/workflows/pr-coverage-comment.yml
@@ -1,0 +1,113 @@
+name: PR Coverage Comment
+
+on:
+  workflow_run:
+    workflows: ["Unit Tests"]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  comment-coverage:
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve PR number
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pullRequests = context.payload.workflow_run.pull_requests || [];
+            if (!pullRequests.length) {
+              core.setFailed('No pull request was associated with this workflow_run.');
+              return;
+            }
+            core.setOutput('number', String(pullRequests[0].number));
+
+      - name: Checkout tested merge ref
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ steps.pr.outputs.number }}/merge
+
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+          pattern: coverage-*
+          path: coverage-artifacts
+          merge-multiple: true
+
+      - name: Prepare coverage tooling
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install coverage==6.5.0
+          sudo ln -sfnT "$GITHUB_WORKSPACE" /code
+
+      - name: Combine coverage data
+        run: |
+          coverage combine coverage-artifacts
+          coverage report --skip-empty --sort=cover > coverage-report.txt
+
+          total_line="$(tail -n 1 coverage-report.txt)"
+          report_lines="$(wc -l < coverage-report.txt | tr -d ' ')"
+
+          {
+            echo '<!-- pr-coverage-comment -->'
+            echo '## Coverage report'
+            echo
+            echo "Workflow: [Unit Tests run](${{ github.event.workflow_run.html_url }})"
+            echo
+            echo "Total: \`$total_line\`"
+            echo
+            echo '<details><summary>Combined coverage report</summary>'
+            echo
+            echo '```text'
+            sed -n '1,25p' coverage-report.txt
+            if [ "$report_lines" -gt 25 ]; then
+              echo "... ($report_lines lines total)"
+            fi
+            echo '```'
+            echo '</details>'
+          } > coverage-comment.md
+
+      - name: Create or update PR comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- pr-coverage-comment -->';
+            const issue_number = Number('${{ steps.pr.outputs.number }}');
+            const body = fs.readFileSync('coverage-comment.md', 'utf8');
+            const { owner, repo } = context.repo;
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+
+            const existing = comments.find(comment =>
+              comment.user.type === 'Bot' && comment.body && comment.body.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -66,5 +66,16 @@ jobs:
         env:
           TEST_BUILD: ${{ matrix.test_build }}
           OSF_TEST_IMAGE: ${{ needs.build-image.outputs.image }}
+          ENABLE_COVERAGE: ${{ github.event_name == 'pull_request' }}
         run: |
           bash .github/scripts/ci/run-tests.sh "$TEST_BUILD"
+
+      - name: Upload coverage artifact
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.test_build }}
+          path: .coverage.${{ matrix.test_build }}
+          if-no-files-found: error
+          include-hidden-files: true
+          retention-days: 1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,6 +4,7 @@
 
 # Testing
 pytest==5.0.0
+pytest-cov==2.12.1
 pytest-socket==0.3.5
 pytest-xdist==1.34.0
 pytest-django==3.10.0


### PR DESCRIPTION
## Summary
- collect Python coverage artifacts during unit-test PR runs
- aggregate coverage in a separate workflow_run workflow
- post or update a single coverage comment on the pull request

## Testing
- bash -n .github/scripts/ci/run-tests.sh
- parsed both workflow YAML files locally
