### PR TITLE
Update coverage baseline on default branch pushes

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -66,12 +66,12 @@ jobs:
         env:
           TEST_BUILD: ${{ matrix.test_build }}
           OSF_TEST_IMAGE: ${{ needs.build-image.outputs.image }}
-          ENABLE_COVERAGE: ${{ github.event_name == 'pull_request' }}
+          ENABLE_COVERAGE: ${{ github.event_name == 'pull_request' || github.ref_name == github.event.repository.default_branch }}
         run: |
           bash .github/scripts/ci/run-tests.sh "$TEST_BUILD"
 
       - name: Upload coverage artifact
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name == 'pull_request' || github.ref_name == github.event.repository.default_branch }}
         uses: actions/upload-artifact@v4
         with:
           name: coverage-${{ matrix.test_build }}
@@ -81,11 +81,11 @@ jobs:
           retention-days: 1
 
   coverage-comment-artifact:
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' || github.ref_name == github.event.repository.default_branch }}
     runs-on: ubuntu-latest
     needs: tests
     permissions:
-      contents: read
+      contents: write
       pull-requests: read
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- run coverage collection on default branch pushes as well as pull requests
- let coverage-comment-artifact update python-coverage-comment-action-data on the default branch
- keep the PR comment flow unchanged so later PRs can compare against the saved baseline

## Test plan
- GitHub Actions
