### PR TITLE
Reload registered_from before logging retraction initiation

### DIFF
--- a/api_tests/nodes/views/test_node_detail.py
+++ b/api_tests/nodes/views/test_node_detail.py
@@ -480,7 +480,6 @@ class TestNodeDetail:
         project_private.deleted = log_date
         project_private.is_deleted = True
         project_private.save()
-        registration.reload()
         project_public.reload()
 
         res = app.get(url)

--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -448,6 +448,10 @@ class Registration(AbstractNode):
             raise NodeStateError('Withdrawal of non-parent registrations is not permitted.')
 
         retraction = self._initiate_retraction(user, justification)
+        # registered_from may hold a stale copy cached at registration time;
+        # add_log() saves the whole row, so reload it to avoid overwriting
+        # newer state (e.g. reviving an already deleted source project).
+        self.refresh_from_db(fields=['registered_from'])
         self.registered_from.add_log(
             action=NodeLog.RETRACTION_INITIATED,
             params={

--- a/tests/test_registrations/test_retractions.py
+++ b/tests/test_registrations/test_retractions.py
@@ -21,7 +21,7 @@ from osf.exceptions import (
     InvalidSanctionApprovalToken, InvalidSanctionRejectionToken,
     NodeStateError,
 )
-from osf.models import Contributor, Retraction
+from osf.models import Contributor, Node, Retraction
 from osf.utils import permissions
 
 
@@ -101,6 +101,21 @@ class RegistrationRetractionModelsTestCase(OsfTestCase):
         assert (self.registration.retraction.justification) == (self.valid_justification)
         assert (self.registration.retraction.initiated_by) == (self.user)
         assert (self.registration.retraction.initiation_date.date()) == (timezone.now().date())
+
+    def test_retract_does_not_revive_deleted_registered_from(self):
+        # A long-lived registration instance (e.g. in a celery task) may hold
+        # registered_from cached from before the source project was deleted;
+        # retraction must not write that stale copy back to the database.
+        assert not self.registration.registered_from.is_deleted
+        source = Node.objects.get(id=self.registration.registered_from_id)
+        source.remove_node(auth=Auth(self.user))
+        source.reload()
+        assert source.is_deleted
+
+        self.registration.retract_registration(self.user, self.valid_justification)
+
+        source.reload()
+        assert source.is_deleted
 
     def test_retract_component_raises_NodeStateError(self):
         project = ProjectFactory(is_public=True, creator=self.user)


### PR DESCRIPTION
## Purpose

  `Registration.retract_registration()` logs RETRACTION_INITIATED via
  `self.registered_from.add_log(...)`, and `add_log()` saves the whole node row.
  When `registered_from` still holds the instance cached at registration time
  (fields_cache), the save writes that stale copy back to the database — for
  example, a source project deleted after the registration was created gets
  revived (`is_deleted` flips back to `False`, and its node links reappear in
  related counts).

  Reproduced on `fix/old-js` (28e1be7d): create a registration of project A
  (which links project B), delete A, then withdraw the registration using the
  same in-memory instance — A comes back undeleted. The existing guard test
  (`test_node_shows_related_count_for_linked_by_relationships`) passes only
  because it calls `registration.reload()` right before the withdrawal, which
  avoids the stale-cache path; long-lived instances (celery tasks, management
  scripts) remain exposed.

  ## Changes

  - Refresh the `registered_from` field cache at the start of
    `retract_registration()` so `add_log()` operates on the current database
    state (1 line + comment).