### PR TITLE
workflowアドオンのアクセス判定に mAP core グループ由来の権限を反映

### DIFF
--- a/addons/workflow/services.py
+++ b/addons/workflow/services.py
@@ -216,7 +216,7 @@ def get_user_accessible_templates(user: OSFUser, **filters) -> List[WorkflowTemp
     Returns:
         List of WorkflowTemplate objects the user can access
     """
-    accessible_nodes = AbstractNode.objects.filter(_contributors=user, is_deleted=False)
+    accessible_nodes = AbstractNode.objects.get_nodes_for_user(user, include_mapcore_groups=True)
 
     visibility_filter = Q(pk__in=[])
     visibility_filter |= Q(visibility=WorkflowTemplate.VISIBILITY_PUBLIC)

--- a/addons/workflow/tests/test_template_access.py
+++ b/addons/workflow/tests/test_template_access.py
@@ -1,0 +1,165 @@
+# -*- coding: utf-8 -*-
+"""Property tests for the template access predicate.
+
+The node-membership branch of template/engine access must admit exactly the
+users who hold an explicit role on a related node: contributors and members
+of mAP core groups bound to the node. Implicit parent-admin READ and public
+visibility of the node itself grant nothing through this branch.
+"""
+
+import uuid
+
+import pytest
+
+from framework.auth.core import Auth
+from framework.exceptions import HTTPError
+
+from osf.models.mapcore_group import MapCoreGroup
+from osf.models.mapcore_node_group import MapCoreNodeGroup
+from osf.models.mapcore_user_group import MapCoreUserGroup
+from osf.utils import permissions
+from osf_tests.factories import (
+    AuthUserFactory,
+    InstitutionFactory,
+    NodeFactory,
+    ProjectFactory,
+)
+from tests.base import OsfTestCase
+
+from addons.workflow.models import (
+    WorkflowActivation,
+    WorkflowDefinitionSnapshot,
+    WorkflowEngine,
+    WorkflowTemplate,
+)
+from addons.workflow.services import get_user_accessible_templates
+from addons.workflow.views import _get_engine_or_404, _get_template_or_404
+
+pytestmark = pytest.mark.django_db
+
+
+class TemplateAccessPredicateTests(OsfTestCase):
+    def setUp(self):
+        super().setUp()
+        self.owner = AuthUserFactory()
+        self.node = ProjectFactory(creator=self.owner)
+        institution = InstitutionFactory()
+        self.engine = WorkflowEngine.objects.create(
+            engine_id=str(uuid.uuid4()),
+            gateway_base_url='https://workflow.example/api/',
+            signing_kid='kid-test',
+            institution=institution,
+        )
+        snapshot = WorkflowDefinitionSnapshot.objects.create(
+            engine=self.engine,
+            definition_id='definition-access',
+            definition_key='definition-access',
+            name='Access Process',
+            version=1,
+        )
+        self.template = WorkflowTemplate.objects.create(
+            node=self.node,
+            definition=snapshot,
+            registered_by=self.owner,
+        )
+
+    def _bind_mapcore_group(self, node, user, permission=permissions.WRITE, enable_addon=True):
+        if enable_addon:
+            node.add_addon('groups', auth=Auth(node.creator))
+        mapcore_group = MapCoreGroup.objects.create(_id='group-{}'.format(uuid.uuid4()))
+        MapCoreNodeGroup.objects.create(
+            node=node,
+            group=node.get_group(permission),
+            mapcore_group=mapcore_group,
+            creator=node.creator,
+        )
+        MapCoreUserGroup.objects.create(user=user, mapcore_group=mapcore_group)
+
+    def _assert_has_access(self, user, template=None, engine=None):
+        template = template or self.template
+        engine = engine or self.engine
+        assert _get_template_or_404(template.pk, user) == template
+        assert _get_engine_or_404(engine.engine_id, user) == engine
+        assert template in get_user_accessible_templates(user)
+
+    def _assert_denied(self, user, template=None, engine=None):
+        template = template or self.template
+        engine = engine or self.engine
+        with pytest.raises(HTTPError) as excinfo:
+            _get_template_or_404(template.pk, user)
+        assert excinfo.value.code == 404
+        with pytest.raises(HTTPError) as excinfo:
+            _get_engine_or_404(engine.engine_id, user)
+        assert excinfo.value.code == 404
+        assert template not in get_user_accessible_templates(user)
+
+    def test_contributor_has_access(self):
+        contributor = AuthUserFactory()
+        self.node.add_contributor(contributor, permissions=permissions.READ, auth=Auth(self.owner), save=True)
+        self._assert_has_access(contributor)
+
+    def test_mapcore_group_member_has_access(self):
+        member = AuthUserFactory()
+        self._bind_mapcore_group(self.node, member)
+        self._assert_has_access(member)
+
+    def _assert_activation_access(self, user):
+        assert _get_template_or_404(self.template.pk, user) == self.template
+        assert _get_engine_or_404(self.engine.engine_id, user) == self.engine
+        # get_user_accessible_templates only lists templates hosted on the
+        # user's own nodes; activation-node members are out of its scope
+        assert self.template not in get_user_accessible_templates(user)
+
+    def test_contributor_has_access_via_activation(self):
+        contributor = AuthUserFactory()
+        activation_node = ProjectFactory()
+        activation_node.add_contributor(contributor, permissions=permissions.READ, auth=Auth(activation_node.creator), save=True)
+        WorkflowActivation.objects.create(
+            node=activation_node,
+            template=self.template,
+            activated_by=self.owner,
+        )
+        self._assert_activation_access(contributor)
+
+    def test_mapcore_group_member_has_access_via_activation(self):
+        member = AuthUserFactory()
+        activation_node = ProjectFactory()
+        self._bind_mapcore_group(activation_node, member)
+        WorkflowActivation.objects.create(
+            node=activation_node,
+            template=self.template,
+            activated_by=self.owner,
+        )
+        self._assert_activation_access(member)
+
+    def test_parent_admin_denied(self):
+        parent_admin = AuthUserFactory()
+        parent = ProjectFactory(creator=parent_admin)
+        component = NodeFactory(parent=parent, creator=self.owner)
+        snapshot = WorkflowDefinitionSnapshot.objects.create(
+            engine=self.engine,
+            definition_id='definition-component',
+            definition_key='definition-component',
+            name='Component Process',
+            version=1,
+        )
+        template = WorkflowTemplate.objects.create(
+            node=component,
+            definition=snapshot,
+            registered_by=self.owner,
+        )
+        assert component.has_permission(parent_admin, permissions.READ)
+        self._assert_denied(parent_admin, template=template)
+
+    def test_stranger_denied_on_public_node(self):
+        self.node.is_public = True
+        self.node.save()
+        self._assert_denied(AuthUserFactory())
+
+    def test_unrelated_user_denied(self):
+        self._assert_denied(AuthUserFactory())
+
+    def test_group_member_denied_when_groups_addon_disabled(self):
+        member = AuthUserFactory()
+        self._bind_mapcore_group(self.node, member, enable_addon=False)
+        self._assert_denied(member)

--- a/addons/workflow/views.py
+++ b/addons/workflow/views.py
@@ -246,15 +246,14 @@ def _get_engine_or_404(engine_id: str, user) -> WorkflowEngine:
 
     has_institution_access = _user_has_engine_admin_access(user, engine)
     if not has_institution_access:
-        accessible_nodes = AbstractNode.objects.filter(_contributors=user, is_deleted=False)
+        accessible_nodes = AbstractNode.objects.get_nodes_for_user(user, include_mapcore_groups=True)
         has_template_access = WorkflowTemplate.objects.filter(
             node__in=accessible_nodes,
             definition__engine=engine,
         ).exists()
         if not has_template_access:
             has_template_access = WorkflowActivation.objects.filter(
-                node___contributors=user,
-                node__is_deleted=False,
+                node__in=accessible_nodes,
                 template__definition__engine=engine,
             ).exists()
 
@@ -293,12 +292,11 @@ def _get_template_or_404(template_id: str, user) -> WorkflowTemplate:
             data={'message': 'Workflow template not found.'},
         )
 
-    has_direct_access = template.node.contributors.filter(id=user.id).exists()
+    has_direct_access = template.node.is_contributor_or_group_member(user)
     if not has_direct_access:
         has_activation_access = WorkflowActivation.objects.filter(
             template=template,
-            node___contributors=user,
-            node__is_deleted=False,
+            node__in=AbstractNode.objects.get_nodes_for_user(user, include_mapcore_groups=True),
         ).exists()
         if not has_activation_access and not _user_can_access_template_via_visibility(user, template):
             raise HTTPError(


### PR DESCRIPTION
## 概要

mAP core グループ管理（#748）は、グループをノードの権限グループ（`node_<id>_admin/write/read`）に紐付け、Contributor と同ランク同等の権限を与える設計です。しかし workflow アドオンのアクセス判定 3 箇所が Contributor 関係（`_contributors`）ベースのままのため、**グループ経由でのみ権限を持つユーザーはテンプレートに到達できず、ワークフローを開始できません**（OASys でプロジェクト選択後の開始 API が 404）。

mAP 対応の漏れとして、この 3 箇所を「関連ノードの権限を明示的に保持しているか（Contributor または グループ）」の判定に置き換えます。

## 変更点

- `_get_template_or_404`（views.py）: `node.contributors.filter(...)` → `node.is_contributor_or_group_member(user)`。activation 経由の到達判定は `get_nodes_for_user(include_mapcore_groups=True)` による集合判定に
- エンジン参照 `_get_engine_or_404`（views.py）: contributor ノード集合 → 同じ権限保持ノード集合
- `get_user_accessible_templates`（services.py）: 同様
- 判定の意味論は「明示的な権限保持者」（OSF の `is_contributor_or_group_member` と同一概念）で、**親プロジェクト admin の暗黙 READ は従来どおり対象外**（挙動変更なし）。テンプレート visibility（PROJECT / INSTITUTION / PUBLIC）の分岐も従来のまま

## テスト

`addons/workflow/tests/test_template_access.py` を新規追加（8件）。ゲートが通す集合・通さない集合を性質として固定:

- Contributor ✓ / mAP core グループメンバー ✓（テンプレートのハブ直属・activation 経由の両方）
- 親プロジェクト admin ✗（`has_permission(READ)` は True であることを併記した上で、gate は従来どおり 404）
- public ノードの無関係者 ✗ / 無関係ユーザー ✗
- groups アドオン無効ノードのグループメンバー ✗（従来挙動）
- activation 経由メンバーはテンプレート一覧に出ない（Contributor と同挙動）

## 動作確認

- addons/workflow テストスイート 131 passed（新規 8 件含む）
- OASys E2E: グループのみユーザーがプロジェクト選択 → ワークフロー開始 → 送信 → 実行確認 → 管理者による中断まで完走（スイート全体 green）

## 依存関係

`AbstractNode.objects.get_nodes_for_user(include_mapcore_groups=True)` と mAP core グループのモデルは #748 以降の develop にのみ存在します。本変更は develop と feature/oasys-service-link のマージ状態が前提で、feature/oasys-service-link 単体には適用できません（本 PR の base はそのマージ状態のブランチです）。

## CI 証跡（fork）

- E2E green: https://github.com/yacchin1205/RDM-OASys-fork/actions/runs/32086154193
- E2E コンポーネント設定: RDM_REPOSITORY yacchin1205/RDM2-osf.io / RDM_BRANCH verify/oasys-service-link-group-fix（本 PR と同内容のマージ） / EMBER_IMAGE yacchin1205/rdm-ember-osf-web:feature_oasys-service-link
